### PR TITLE
Some small performance tweaks

### DIFF
--- a/R/internals.R
+++ b/R/internals.R
@@ -315,13 +315,14 @@ swap.cases <- function(param, config, i){
 ## and return correct IDs
 ## (non-exported)
 check.i <- function(data, i){
-    if(is.null(i)) return(seq.int(data$N))
-    if(!is.numeric(i)) stop("i is not numeric")
-    if(any(is.na(i))) stop("NA detected in case IDs")
-    if(length(i)==0L) stop("i has length zero")
-    if(any(i < 1)) stop("i contains invalid case indices (i<1)")
-    if(any(i > data$N)) stop("i contains invalid case indices (i>dat$N)")
-    return(i)
+    if (is.null(i)) seq_len(data$N) else i
+    ## if(is.null(i)) return(seq.int(data$N))
+    ## if(!is.numeric(i)) stop("i is not numeric")
+    ## if(any(is.na(i))) stop("NA detected in case IDs")
+    ## if(length(i)==0L) stop("i has length zero")
+    ## if(any(i < 1)) stop("i contains invalid case indices (i<1)")
+    ## if(any(i > data$N)) stop("i contains invalid case indices (i>dat$N)")
+    ## return(i)
 } # end check.i
 
 


### PR DESCRIPTION
This should be good enough for about ~35 speed up; 11.8 vs 17.1s on

```
data(fakeOutbreak)
dat <- fakeOutbreak$dat
w <- fakeOutbreak$w

set.seed(1)
system.time(
out <- outbreaker(data=list(dna=dat$dna, dates=dat$onset, w.dens=w),
                   config=list(n.iter=100, sample.every=5)))
```

However, they are not extensively tested and this does disable a bunch
of testing.  I think that the testing is in the wrong place - we still
need to do it, but not in the main loop as is currently done.