### PR TITLE
Enable C++11 support

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,3 +28,4 @@ LazyData: true
 LinkingTo:
     Rcpp
 RoxygenNote: 5.0.1
+SystemRequirements: C++11


### PR DESCRIPTION
The package uses C++11 features (or triggers something that does), and
this needs flagging, either in the Makevars or in DESCRIPTION (as done here).

See https://cran.r-project.org/doc/manuals/r-release/R-exts.html#Using-C_002b_002b11-code

This is tested on @finlaycampbell's machine